### PR TITLE
Fix variable name in forces prompt function

### DIFF
--- a/local_agents/forces_agent.py
+++ b/local_agents/forces_agent.py
@@ -47,10 +47,10 @@ Return **valid JSON** that conforms to the FiveForcesResult schema.
 )
 
 def generate_forces_prompt(profile, bg, crux, token_budget):
-    dict = {
+    payload = {
         "company_profile": profile,
         "pest_bullets": bg["pest"]["pest_bullets"],
         "trend_clusters": bg["trend_radar"]["trend_clusters"],
         "initial_crux": as_token_limited_json(crux, token_budget)
     }
-    return json.dumps(dict, indent=2, ensure_ascii=False)
+    return json.dumps(payload, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- rename `dict` variable to `payload` in `generate_forces_prompt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686304bc4a988325911c2e147614f57f