### PR TITLE
Ensure Five‑Forces JSON always assessed

### DIFF
--- a/local_agents/generic_assessor_agent.py
+++ b/local_agents/generic_assessor_agent.py
@@ -17,7 +17,10 @@ Task: evaluate ONE or several strategic‑analysis reports produced by
 other AI agents. The reports may employ any framework (Porter, VRIO,
 PEST, Blue‑Ocean, etc.). Your scoring rubric is **framework‑agnostic**;
 focus on rigor, evidence use, and insight depth rather than the specific
-model chosen.
+model chosen. First, parse the generator's JSON and ensure it matches
+the schema supplied in the conversation. If the JSON does not conform to
+the schema, the score is "fail" and the feedback must briefly list the
+missing or malformed fields.
 
 If multiple reports are concatenated, score each separately (report #1,
 report #2, …).
@@ -46,6 +49,8 @@ Rules
 • If the input text is empty or has <100 characters, return:
   report_number, score, explainability, completeness, analytical_depth, creativity
   1,0,0,0,0,0
+• If the supplied JSON does not match the provided schema, score = fail and
+  explain briefly which fields are missing or malformed.
   Fail criteria:
 1. Any in-text citation that does **not** match: \(CapitalisedWord, 4-digit-year\)
    RegEx:  \([A-Z][A-Za-z0-9]+, [0-9]{4}\)

--- a/pipeline/builders.py
+++ b/pipeline/builders.py
@@ -101,7 +101,7 @@ def _run(agent, prompt: str, label: str, rounds: int = 1):
     Call LLM generator + citation-verifier (+ optional assessor) and
     return parsed JSON/str.
     """
-    assessor = ASSESSOR_MAP.get(label)
+    assessor = ASSESSOR_MAP.get(label, generic_assessor_agent)
     raw = run_single_workflow_with_verifier(
         generator_agent=agent,
         verifier_agent=citation_verifier_agent,


### PR DESCRIPTION
## Summary
- always supply an assessor when running a builder
- expand `generic_assessor_agent` instructions to validate schema and fail when mismatched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864291b704483259c92a2a351a0b914